### PR TITLE
correct name length tests

### DIFF
--- a/spec/unit/azure_network_interface_spec.rb
+++ b/spec/unit/azure_network_interface_spec.rb
@@ -21,7 +21,7 @@ describe Chef::Resource::AzureNetworkInterface do
   # end
 
   it 'raises an error when resource group is longer than 80 characters long' do
-    eighty_one_character_name = 81.times { 'n' }
+    eighty_one_character_name = 'n' * 81
     expect { resource.new(eighty_one_character_name).name }.to raise_error(Chef::Exceptions::ValidationFailed)
   end
 

--- a/spec/unit/azure_resource_group_spec.rb
+++ b/spec/unit/azure_resource_group_spec.rb
@@ -12,7 +12,7 @@ describe Chef::Resource::AzureResourceGroup do
   # end
 
   it 'does not instantiate when name is longer than 80 characters long' do
-    eighty_one_character_name = 81.times { 'n' }
+    eighty_one_character_name = 'n' * 81
     expect { resource.new(eighty_one_character_name).name }.to raise_error(Chef::Exceptions::ValidationFailed)
   end
 


### PR DESCRIPTION
it looks like both of the failing tests were due to the fact that we were incorrectly mocking the name and it wasn't properly causing a failure.
